### PR TITLE
Add Claude skill for fetching GitHub Actions logs

### DIFF
--- a/.claude/skills/fetch-action-logs/SKILL.md
+++ b/.claude/skills/fetch-action-logs/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: fetch-action-logs
+description: Fetch and display logs for a GitHub Actions run. Use when the user asks to get, check, or view CI logs for a GitHub Actions run.
+allowed-tools: Bash(curl*), Bash(unzip*), Bash(gh run list*), Bash(gh repo view*)
+---
+
+# Fetch GitHub Actions Run Logs
+
+## Finding the run ID
+
+If no run ID is provided, list recent runs:
+
+```bash
+gh run list --limit 5
+```
+
+The run ID is the numeric ID in the output (second to last column).
+
+## Downloading logs
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+curl -L \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$REPO/actions/runs/<RUN_ID>/logs" \
+  -o /tmp/gh_logs.zip
+```
+
+## Extracting and displaying logs
+
+```bash
+rm -rf /tmp/gh_logs && unzip -o /tmp/gh_logs.zip -d /tmp/gh_logs/
+```
+
+Then read the relevant log files from `/tmp/gh_logs/` to show the user what happened.
+
+## Getting logs for a specific job
+
+```bash
+curl -L \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$REPO/actions/jobs/<JOB_ID>/logs" \
+  -o /tmp/gh_job.log
+```
+
+The job endpoint returns plain text instead of a zip.

--- a/.claude/skills/fetch-action-logs/SKILL.md
+++ b/.claude/skills/fetch-action-logs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fetch-action-logs
 description: Fetch and display logs for a GitHub Actions run. Use when the user asks to get, check, or view CI logs for a GitHub Actions run.
-allowed-tools: Bash(curl*), Bash(unzip*), Bash(gh run list*), Bash(gh repo view*)
+allowed-tools: Bash(curl*), Bash(rm -rf /tmp/gh_logs*), Bash(unzip*), Bash(gh run list*), Bash(gh repo view*)
 ---
 
 # Fetch GitHub Actions Run Logs

--- a/.claude/skills/fix-pr-comments/SKILL.md
+++ b/.claude/skills/fix-pr-comments/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: fix-pr-comments
+description: Read review comments on a GitHub PR and fix the issues raised. Use when the user asks to address, fix, or resolve PR comments or review feedback.
+allowed-tools: Bash(gh pr view*), Bash(gh api*)
+---
+
+# Fix PR Comments
+
+## Finding the PR
+
+If no PR number is provided, find the current branch's PR:
+
+```bash
+gh pr view --json number,url -q '.number'
+```
+
+## Reading review comments
+
+Get both general comments and inline review comments:
+
+```bash
+# General PR comments
+gh pr view <PR_NUMBER> --json comments,reviews --jq '.comments[], .reviews[]'
+
+# Inline review comments (on specific lines of code)
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+```
+
+## Workflow
+
+1. Fetch all comments using the commands above
+2. Parse each comment to understand what change is being requested
+3. Ignore bot comments that are purely informational (e.g. CI status)
+4. For each actionable comment, make the requested fix in the codebase
+5. Run the linter (`make style && make quality`) and tests (`uv run pytest`) after making changes
+6. Commit and push the fixes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agents
+
+## Skills
+
+### fetch-action-logs
+
+Fetch and display logs for a GitHub Actions run using the GitHub API.
+
+**Location:** `.claude/skills/fetch-action-logs/SKILL.md`
+
+**Usage:** Ask Claude to fetch CI logs or check a GitHub Actions run. Provide a run ID, or it will list recent runs and pick the latest.
+
+**Requires:** `GITHUB_TOKEN` environment variable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,11 @@ Fetch and display logs for a GitHub Actions run using the GitHub API.
 **Usage:** Ask Claude to fetch CI logs or check a GitHub Actions run. Provide a run ID, or it will list recent runs and pick the latest.
 
 **Requires:** `GITHUB_TOKEN` environment variable.
+
+### fix-pr-comments
+
+Read review comments on a GitHub PR and fix the issues raised.
+
+**Location:** `.claude/skills/fix-pr-comments/SKILL.md`
+
+**Usage:** Ask Claude to read and fix PR comments. Provide a PR number, or it will use the current branch's PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
- Adds a Claude Code skill (`fetch-action-logs`) that downloads and displays GitHub Actions run logs via the GitHub API
- Adds `AGENTS.md` to document available Claude skills
- Adds `CLAUDE.md` as a symlink to `AGENTS.md`